### PR TITLE
enable programmatic access to credentials object

### DIFF
--- a/src/aws_okta_processor/commands/authenticate.py
+++ b/src/aws_okta_processor/commands/authenticate.py
@@ -35,7 +35,7 @@ CONFIG_MAP = {
 
 
 class Authenticate(Base):
-    def authenticate(self)
+    def authenticate(self):
         cache = JSONFileCache()
         saml_fetcher = SAMLFetcher(
             self,
@@ -45,7 +45,7 @@ class Authenticate(Base):
         credentials = saml_fetcher.fetch_credentials()
 
         return credentials
-    
+
     def run(self):
 
         credentials = self.authenticate()

--- a/src/aws_okta_processor/commands/authenticate.py
+++ b/src/aws_okta_processor/commands/authenticate.py
@@ -35,7 +35,7 @@ CONFIG_MAP = {
 
 
 class Authenticate(Base):
-    def run(self):
+    def authenticate(self)
         cache = JSONFileCache()
         saml_fetcher = SAMLFetcher(
             self,
@@ -43,6 +43,12 @@ class Authenticate(Base):
         )
 
         credentials = saml_fetcher.fetch_credentials()
+
+        return credentials
+    
+    def run(self):
+
+        credentials = self.authenticate()
 
         if self.configuration["AWS_OKTA_ENVIRONMENT"]:
             if os.name == 'nt':


### PR DESCRIPTION
This will allow us to ...

```python
auth_options = {
    '--user': username,
    '--organization': org,
    '--key': md5_cache_name.hexdigest(),
    '--duration': session_duration,
    '--silent': True,
    '--role': role,
    '--pass': str(credentials['password']).rstrip('\n'),
    '--application': app
}
for k in authenticate.CONFIG_MAP.keys():
    if k not in auth_options:
        auth_options[k] = None

auth_cmd = Authenticate(auth_options)
aws_auth = auth_cmd.authenticate()
```