### PR TITLE
Adds --target-shell option to authenticate command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,12 @@ For Linux or OSX run::
 
     $ eval $(aws-okta-processor authenticate --environment --user <user_name> --organization <organization>.okta.com)
 
+On Unix systems is allowed to pass a `--target-shell` in order to change the
+export command output. Bash is the default target shell.
+We also allow [fish shell](https://fishshell.com/) as a valid target::
+
+    $ eval (aws-okta-processor authenticate --environment --user <user_name> --organization <organization>.okta.com --target-shell fish)
+
 For Windows run::
 
     $ Invoke-Expression (aws-okta-processor authenticate --environment --user <user_name> --organization <organization>.okta.com)
@@ -135,6 +141,8 @@ factor        --factor                               MFA type. `push:okta` and `
 no_okta_cache --no-okta-cache AWS_OKTA_NO_OKTA_CACHE Do not read okta cache
 ------------- --------------- ---------------------- ----------------------------------------
 no_aws_cache  --no-aws-cache  AWS_OKTA_NO_AWS_CACHE  Do not read aws cache
+------------- --------------- ---------------------- ----------------------------------------
+target_shell  --target-shell  AWS_OKTA_TARGET_SHELL  Target shell to format export command
 ============= =============== ====================== ========================================
 
 ^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ For Linux or OSX run::
 
     $ eval $(aws-okta-processor authenticate --environment --user <user_name> --organization <organization>.okta.com)
 
-On Unix systems is allowed to pass a `--target-shell` in order to change the
+On Unix systems pass a `--target-shell` in order to change the
 export command output. Bash is the default target shell.
 We also allow [fish shell](https://fishshell.com/) as a valid target::
 

--- a/src/aws_okta_processor/cli.py
+++ b/src/aws_okta_processor/cli.py
@@ -11,6 +11,7 @@ Usage:
                                   [--key=<key>]
                                   [--factor=<factor>]
                                   [--silent] [--no-okta-cache] [--no-aws-cache]
+                                  [--target-shell=<target_shell>]
 
   aws-okta-processor -h | --help
   aws-okta-processor --version
@@ -31,6 +32,7 @@ Options:
   -k <key> --key=<key>                                       Key used for generating and accessing cache.
   -f <factor> --factor=<factor>                              Factor type for MFA.
   -s --silent                                                Run silently.
+  --target-shell <target_shell>                              Target shell to output the export command.
 
 Help:
   For help using this tool, please reach out to our Slack channel:

--- a/src/aws_okta_processor/commands/authenticate.py
+++ b/src/aws_okta_processor/commands/authenticate.py
@@ -15,8 +15,8 @@ UNIX_EXPORT_STRING = ("export AWS_ACCESS_KEY_ID='{}' && "
                       "export AWS_SESSION_TOKEN='{}'")
 
 UNIX_FISH_EXPORT_STRING = ("set --export AWS_ACCESS_KEY_ID '{}'; and "
-                      "set --export AWS_SECRET_ACCESS_KEY '{}'; and "
-                      "set --export AWS_SESSION_TOKEN '{}';")
+                           "set --export AWS_SECRET_ACCESS_KEY '{}'; and "
+                           "set --export AWS_SESSION_TOKEN '{}';")
 
 NT_EXPORT_STRING = ("$env:AWS_ACCESS_KEY_ID='{}'; "
                     "$env:AWS_SECRET_ACCESS_KEY='{}'; "

--- a/src/aws_okta_processor/commands/authenticate.py
+++ b/src/aws_okta_processor/commands/authenticate.py
@@ -75,20 +75,37 @@ class Authenticate(Base):
 
         if self.configuration["AWS_OKTA_ENVIRONMENT"]:
             if os.name == 'nt':
-                print(NT_EXPORT_STRING.format(
-                    credentials["AccessKeyId"],
-                    credentials["SecretAccessKey"],
-                    credentials["SessionToken"]
-                ))
+                print(self.nt_output(credentials))
             else:
-                print(UNIX_EXPORT_STRING.format(
-                    credentials["AccessKeyId"],
-                    credentials["SecretAccessKey"],
-                    credentials["SessionToken"]
-                ))
+                print(self.unix_output(credentials))
+
         else:
             credentials["Version"] = 1
             print(json.dumps(credentials))
+
+    def nt_output(self, credentials):
+        """ Outputs the export command for Windows based systems """
+
+        return NT_EXPORT_STRING.format(
+            credentials["AccessKeyId"],
+            credentials["SecretAccessKey"],
+            credentials["SessionToken"]
+        )
+
+    def unix_output(self, credentials):
+        """ Checks which shell target we should output the export command """
+
+        # We assume Bash as the default shell target
+        export_string = UNIX_EXPORT_STRING
+
+        if self.configuration["AWS_OKTA_TARGET_SHELL"] == "fish":
+            export_string = UNIX_FISH_EXPORT_STRING
+
+        return export_string.format(
+            credentials["AccessKeyId"],
+            credentials["SecretAccessKey"],
+            credentials["SessionToken"]
+        )
 
     def get_pass(self):
         if self.configuration["AWS_OKTA_PASS"]:

--- a/src/aws_okta_processor/commands/authenticate.py
+++ b/src/aws_okta_processor/commands/authenticate.py
@@ -14,6 +14,10 @@ UNIX_EXPORT_STRING = ("export AWS_ACCESS_KEY_ID='{}' && "
                       "export AWS_SECRET_ACCESS_KEY='{}' && "
                       "export AWS_SESSION_TOKEN='{}'")
 
+UNIX_FISH_EXPORT_STRING = ("set --export AWS_ACCESS_KEY_ID '{}'; and "
+                      "set --export AWS_SECRET_ACCESS_KEY '{}'; and "
+                      "set --export AWS_SESSION_TOKEN '{}';")
+
 NT_EXPORT_STRING = ("$env:AWS_ACCESS_KEY_ID='{}'; "
                     "$env:AWS_SECRET_ACCESS_KEY='{}'; "
                     "$env:AWS_SESSION_TOKEN='{}'")

--- a/src/aws_okta_processor/commands/authenticate.py
+++ b/src/aws_okta_processor/commands/authenticate.py
@@ -35,7 +35,8 @@ CONFIG_MAP = {
             "--silent": "AWS_OKTA_SILENT",
             "--no-okta-cache": "AWS_OKTA_NO_OKTA_CACHE",
             "--no-aws-cache": "AWS_OKTA_NO_AWS_CACHE",
-            "--account-alias": "AWS_OKTA_ACCOUNT_ALIAS"
+            "--account-alias": "AWS_OKTA_ACCOUNT_ALIAS",
+            "--target-shell": "AWS_OKTA_TARGET_SHELL"
         }
 
 EXTEND_CONFIG_MAP = {
@@ -51,7 +52,8 @@ EXTEND_CONFIG_MAP = {
             "AWS_OKTA_SILENT": "silent",
             "AWS_OKTA_NO_OKTA_CACHE": "no-okta-cache",
             "AWS_OKTA_NO_AWS_CACHE": "no-aws-cache",
-            "AWS_OKTA_ACCOUNT_ALIAS": "account-alias"
+            "AWS_OKTA_ACCOUNT_ALIAS": "account-alias",
+            "AWS_OKTA_TARGET_SHELL": "target-shell"
         }
 
 

--- a/tests/commands/test_authenticate.py
+++ b/tests/commands/test_authenticate.py
@@ -7,6 +7,54 @@ from tests.test_base import TestBase
 
 
 class TestAuthenticate(TestBase):
+
+    def test_output_export_command_with_fish_as_target_shell(self):
+        """ Tests the export command for fish shell """
+
+        self.OPTIONS["--target-shell"] = "fish"
+        auth = Authenticate(self.OPTIONS)
+        credentials = {
+            "AccessKeyId": "XXXXX",
+            "SecretAccessKey": "YYYYY",
+            "SessionToken": "ZZZZZ"
+        }
+        self.assertNotIsInstance(
+            auth.unix_output(credentials).index("set --export"),
+            ValueError
+        )
+
+    def test_output_export_command_with_default_target_shell(self):
+        """ Tests the export command for bash (default target shell) """
+
+        auth = Authenticate(self.OPTIONS)
+        credentials = {
+            "AccessKeyId": "XXXXX",
+            "SecretAccessKey": "YYYYY",
+            "SessionToken": "ZZZZZ"
+        }
+        self.assertNotIsInstance(
+            auth.unix_output(credentials).index("export "),
+            ValueError
+        )
+        self.assertNotIsInstance(
+            auth.unix_output(credentials).index(" && "),
+            ValueError
+        )
+
+    def test_output_export_command_for_windows(self):
+        """ Tests the export command for windows operating system """
+
+        auth = Authenticate(self.OPTIONS)
+        credentials = {
+            "AccessKeyId": "XXXXX",
+            "SecretAccessKey": "YYYYY",
+            "SessionToken": "ZZZZZ"
+        }
+        self.assertNotIsInstance(
+            auth.nt_output(credentials).index("$env:"),
+            ValueError
+        )
+
     def test_get_pass_config(self):
         self.OPTIONS["--pass"] = "user_pass_two"
         authenticate = Authenticate(self.OPTIONS)


### PR DESCRIPTION
Hey, folks.

This Pull Request adds a new command line option to read what is the target shell which the 
export command will run. Default shell is `bash` and this PR adds support  for [fish shell](https://fishshell.com/) as well. So with that, developers can use `aws-okta-processor` as follows:

```bash
⋊> aws-okta-processor authenticate --environment --organization=myorg.okta.com --user=myuser --target-shell fish
set --export AWS_ACCESS_KEY_ID 'XXXX'; and set --export AWS_SECRET_ACCESS_KEY 'YYYY'; and set --export AWS_SESSION_TOKEN 'ZZZZ';
```


Also, this Pull Request increases the test coverage of the `commands/authenticate.py` from
5% to 10% and adds documentation about the new command line option.

> I believe this Pull Request can help other developers who uses `aws-okta-processor` in a daily
> basis inside a fish shell environment. Also, I designed the code in a way other shells like 
> zsh and ash can be added in the future with easy.  

All the best and thank you for this project!