### PR TITLE
fix(get-roles): support accounts with no alias

### DIFF
--- a/aws_okta_processor/commands/getroles.py
+++ b/aws_okta_processor/commands/getroles.py
@@ -81,9 +81,11 @@ class GetRoles(Base):
 
         accounts = app_and_role["Accounts"]
         for name_raw in accounts:
-            account_parts = re.match(r"(Account:) ([a-zA-Z0-9-_]+) \(([0-9]+)\)", name_raw)
+            account_parts = re.match(
+                r"(Account:) ([a-zA-Z0-9-_]+)(?: \(([0-9]+)\))?", name_raw
+            )
             account = account_parts[2]
-            account_id = account_parts[3]
+            account_id = account_parts[3] or account_parts[2]
             roles = accounts[name_raw]
             result_roles = []
             result_account = {


### PR DESCRIPTION
Proposed fix for #49 that involves as little change as possible. Substitutes account_id for the account alias in the event that the alias does not exist.