### PR TITLE
Authentication locks tools without stdin - windows credentials support hack

### DIFF
--- a/aws_okta_processor/core/okta.py
+++ b/aws_okta_processor/core/okta.py
@@ -1,11 +1,12 @@
 import abc
+import base64
 import os
 import sys
 import time
 import json
 import requests
 import dateutil
-import getpass
+import subprocess
 import aws_okta_processor.core.prompt as prompt
 
 from datetime import datetime
@@ -78,21 +79,28 @@ class Okta:
             self.user_name = input()
 
         if not self.okta_session_id:
-            if not self.user_name:
-                print_tty(string="UserName: ", newline=False)
-                self.user_name = input()
+            # if not self.user_name:
+            #     print_tty(string="UserName: ", newline=False)
+            #     self.user_name = input()
+            
+            getCredentialCommand = f"(Get-Credential -Message 'aws-okta-processor is requesting credentials for {self.organization}' -UserName {self.user_name}).GetNetworkCredential() | ConvertTo-Json"
+            encodedCommand = base64.b64encode(getCredentialCommand.encode("utf-16")[2:]).decode("utf-8")
+            powershellCommand = f"powershell.exe -NoProfile -NonInteractive -OutputFormat Text -EncodedCommand {encodedCommand}"
+            output = subprocess.check_output(powershellCommand)
+            wincreds = json.loads(output)
 
-            if not user_pass:
-                user_pass = getpass.getpass()
+            # if not user_pass:
+            #     user_pass = getpass.getpass()
 
-            if not self.organization:
-                print_tty(string="Organization: ", newline=False)
-                self.organization = input()
+            # if not self.organization:
+            #     print_tty(string="Organization: ", newline=False)
+            #     self.organization = input()
 
             self.okta_single_use_token = self.get_okta_single_use_token(
-                user_name=self.user_name,
-                user_pass=user_pass
+                user_name=wincreds['UserName'],
+                user_pass=wincreds['Password']
             )
+            wincreds = None
 
             self.get_okta_session_id()
 


### PR DESCRIPTION
This pull request isn't intended to be merged as-is, but it's here to demonstrate an issue and hack solution for a problem with `aws-okta-processor`.

If you work with AWS entirely from the command line, then `aws-okta-processor` is fine. But if you ever use an AWS-aware tool that doesn't redirect `stdin` and `stdout` then aws-okta-processor, when configured as a `credential_process`, will wait indefinitely for user prompts that the user never receives. As an example: [AWS Tools for Powershell](https://aws.amazon.com/powershell/) breaks when `aws-okta-processor` prompts as, for some reason, it doesn't redirect stdin/stdout.

The hack I'm presenting here is a partial solution to the problem. Instead of using Python's `getpass`, I'm leveraging Powershell.exe to call `Get-Credentials` which shows the standard Windows credentials prompt. Preferably the call to Powershell should be replaced with real winapi calls, but that is considerably more effort. It also doesn't solve the problem for other operating systems. Also, I'm not handling hardware token prompts at all so that will still fail silently.

The proper solution here would be for `aws-okta-processor` to detect if it's running interactively and/or expose flags to control interactivity. If the process is non-interactive or is disabled by flags then it should not prompt for input and fail quickly when invoked. If the process is interactive then show the user prompt, depending on what input is available. Preferably leveraging secure credentials prompts provided by the user's operating system.