### PR TITLE
Retry okta session

### DIFF
--- a/aws_okta_processor/core/fetcher.py
+++ b/aws_okta_processor/core/fetcher.py
@@ -50,7 +50,7 @@ class SAMLFetcher(CachedCredentialFetcher):
         user_pass = self._authenticate.get_pass()
         organization = self._configuration["AWS_OKTA_ORGANIZATION"]
         no_okta_cache = self._configuration["AWS_OKTA_NO_OKTA_CACHE"]
-        
+
         okta = Okta(
             user_name=user,
             user_pass=user_pass,
@@ -98,11 +98,11 @@ class SAMLFetcher(CachedCredentialFetcher):
             saml_assertion = saml.get_saml_assertion(
                 saml_response=saml_response
             )
-                
+
         if not saml_assertion:
             print_tty("ERROR: SAMLResponse tag was not found!")
             sys.exit(1)
-            
+
         aws_roles = saml.get_aws_roles(
             saml_assertion=saml_assertion,
             accounts_filter=self._configuration.get(

--- a/aws_okta_processor/core/fetcher.py
+++ b/aws_okta_processor/core/fetcher.py
@@ -1,5 +1,6 @@
 import boto3
 import json
+import sys
 
 import aws_okta_processor.core.saml as saml
 import aws_okta_processor.core.prompt as prompt
@@ -46,14 +47,17 @@ class SAMLFetcher(CachedCredentialFetcher):
 
     def _get_app_roles(self):
         user = self._configuration["AWS_OKTA_USER"]
+        user_pass = self._authenticate.get_pass()
         organization = self._configuration["AWS_OKTA_ORGANIZATION"]
+        no_okta_cache = self._configuration["AWS_OKTA_NO_OKTA_CACHE"]
+        
         okta = Okta(
             user_name=user,
-            user_pass=self._authenticate.get_pass(),
+            user_pass=user_pass,
             organization=organization,
             factor=self._configuration["AWS_OKTA_FACTOR"],
             silent=self._configuration["AWS_OKTA_SILENT"],
-            no_okta_cache=self._configuration["AWS_OKTA_NO_OKTA_CACHE"]
+            no_okta_cache=no_okta_cache
         )
 
         self._configuration["AWS_OKTA_USER"] = ''
@@ -73,11 +77,32 @@ class SAMLFetcher(CachedCredentialFetcher):
         saml_response = okta.get_saml_response(
             application_url=application_url
         )
-
         saml_assertion = saml.get_saml_assertion(
             saml_response=saml_response
         )
 
+        if not saml_assertion and not no_okta_cache:
+            # Try again, but without using the cached Okta session
+            print_tty("Creating new Okta session.")
+            okta = Okta(
+                user_name=user,
+                user_pass=user_pass,
+                organization=organization,
+                factor=self._configuration["AWS_OKTA_FACTOR"],
+                silent=self._configuration["AWS_OKTA_SILENT"],
+                no_okta_cache=True
+            )
+            saml_response = okta.get_saml_response(
+                application_url=application_url
+            )
+            saml_assertion = saml.get_saml_assertion(
+                saml_response=saml_response
+            )
+                
+        if not saml_assertion:
+            print_tty("ERROR: SAMLResponse tag was not found!")
+            sys.exit(1)
+            
         aws_roles = saml.get_aws_roles(
             saml_assertion=saml_assertion,
             accounts_filter=self._configuration.get(

--- a/aws_okta_processor/core/okta.py
+++ b/aws_okta_processor/core/okta.py
@@ -96,7 +96,7 @@ class Okta:
                 user_pass=user_pass
             )
 
-            # This call sets self.okta_session_id and
+            # This call sets self.okta_session_id
             self.create_and_store_okta_session()
 
     def read_aop_from_okta_session(self, okta_session):
@@ -238,7 +238,6 @@ class Okta:
 
     def create_and_store_okta_session(self):
         """ Creates a new Okta session and caches it in our cache file for future use.
-        
         https://developer.okta.com/docs/reference/api/sessions/#get-started
         """
         headers = {

--- a/aws_okta_processor/core/okta.py
+++ b/aws_okta_processor/core/okta.py
@@ -60,9 +60,11 @@ class Okta:
         okta_session = None
 
         if not no_okta_cache:
-            okta_session = self.get_okta_session()
+            # Get session from cache
+            okta_session = self.get_okta_session_from_cache_file()
 
         if okta_session:
+            # Refresh the session ID of the cached session
             self.read_aop_from_okta_session(okta_session)
 
             self.refresh_okta_session_id(
@@ -94,7 +96,8 @@ class Okta:
                 user_pass=user_pass
             )
 
-            self.get_okta_session_id()
+            # This call sets self.okta_session_id and
+            self.create_and_store_okta_session()
 
     def read_aop_from_okta_session(self, okta_session):
         if "aws-okta-processor" in okta_session:
@@ -105,6 +108,9 @@ class Okta:
             del okta_session["aws-okta-processor"]
 
     def get_cache_file_path(self):
+        """ Returns the file path for the session cache file:
+        ~/.aws-okta-processor/cache/<username>-<organization>-session.json
+        """
         home_directory = os.path.expanduser('~')
         cache_directory = os.path.join(
             home_directory,
@@ -125,6 +131,7 @@ class Okta:
         return cache_file_path
 
     def set_okta_session(self, okta_session=None):
+        """ Saves the given Okta session in our cache file. """
         session_data = dict(okta_session, **{
             "aws-okta-processor": {
                 "user_name": self.user_name,
@@ -136,7 +143,7 @@ class Okta:
 
         os.chmod(self.cache_file_path, 0o600)
 
-    def get_okta_session(self):
+    def get_okta_session_from_cache_file(self):
         session = {}
 
         if os.path.isfile(self.cache_file_path):
@@ -229,7 +236,11 @@ class Okta:
 
         send_error(response=response)
 
-    def get_okta_session_id(self):
+    def create_and_store_okta_session(self):
+        """ Creates a new Okta session and caches it in our cache file for future use.
+        
+        https://developer.okta.com/docs/reference/api/sessions/#get-started
+        """
         headers = {
             "Accept": "application/json",
             "Content-Type": "application/json"

--- a/aws_okta_processor/core/saml.py
+++ b/aws_okta_processor/core/saml.py
@@ -25,10 +25,16 @@ def get_saml_assertion(saml_response=None):
         if input_tag.get('name') == 'SAMLResponse':
             return input_tag.get('value')
 
-    if soup.find('div', {"id": "okta-sign-in"}) or soup.find('div', {"id": "password-verification-challenge"}):
-        # No assertion in the response, since Okta is presenting an MFA or password challenge. The okta session
-        # we supplied is not sufficient.
-        print_tty("SAMLResponse tag not found.")
+    if soup.find('div', {"id": "okta-sign-in"}):
+        # Supplied Okta session not sufficient to get SAML assertion.
+        # This condition may be missed if Okta significantly changes the app-level MFA page
+        print_tty("SAMLResponse tag not found due to MFA challenge.")
+        return None
+
+    if soup.find('div', {"id": "password-verification-challenge"}):
+        # Supplied Okta session not sufficient to get SAML assertion.
+        # This condition may be missed if Okta significantly changes the app-level re-auth page
+        print_tty("SAMLResponse tag not found due to password verification challenge.")
         return None
 
     print_tty("ERROR: SAMLResponse tag was not found!")

--- a/aws_okta_processor/core/saml.py
+++ b/aws_okta_processor/core/saml.py
@@ -18,11 +18,18 @@ AWS_SIGN_IN_URL = "https://signin.aws.amazon.com/saml"
 
 
 def get_saml_assertion(saml_response=None):
+    """ Extracts the SAML assertion from the saml_response HTML by finding the appropriate HTML element. """
     soup = BeautifulSoup(saml_response, "html.parser")
 
     for input_tag in soup.find_all('input'):
         if input_tag.get('name') == 'SAMLResponse':
             return input_tag.get('value')
+
+    if soup.find('div', {"id": "okta-sign-in"}) or soup.find('div', {"id": "password-verification-challenge"}):
+        # No assertion in the response, since Okta is presenting an MFA or password challenge. The okta session
+        # we supplied is not sufficient.
+        print_tty("SAMLResponse tag not found.")
+        return None
 
     print_tty("ERROR: SAMLResponse tag was not found!")
     sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ REQUIRES = [
     'boto3>=1.9.134',
     'bs4>=0.0.1',
     'contextlib2>=0.5.5',
-    'six>=1.12.0'
+    'six>=1.12.0',
+    'defusedxml>=0.7.1'
 ]
 
 TEST_REQUIREMENTS = [

--- a/tests/core/test_okta.py
+++ b/tests/core/test_okta.py
@@ -297,7 +297,7 @@ class TestOkta(TestBase):
         self.assertEqual(okta.okta_session_id, "session_token")
 
     @patch('aws_okta_processor.core.okta.Okta.get_okta_single_use_token')
-    @patch('aws_okta_processor.core.okta.Okta.get_okta_session_id')
+    @patch('aws_okta_processor.core.okta.Okta.create_and_store_okta_session')
     @patch('aws_okta_processor.core.okta.input')
     def test_read_aop_from_okta_session_should_read_aop_options(
         self,
@@ -325,7 +325,7 @@ class TestOkta(TestBase):
     @patch('aws_okta_processor.core.okta.os.chmod')
     @patch('aws_okta_processor.core.okta.Okta.get_cache_file_path', return_value='/tmp/test.json')
     @patch('aws_okta_processor.core.okta.Okta.get_okta_single_use_token')
-    @patch('aws_okta_processor.core.okta.Okta.get_okta_session_id')
+    @patch('aws_okta_processor.core.okta.Okta.create_and_store_okta_session')
     @patch('aws_okta_processor.core.okta.input')
     @patch('builtins.open', new_callable=mock_open)
     def test_set_okta_session_should_write_session_data(


### PR DESCRIPTION
This PR causes the tool to retry fetching SAML assertions when the initial try was making use of a cached Okta session and Okta is responding with an MFA or password challenge. The MFA / password challenge detection is based on the okta-aws-cli-assume-role repo: https://github.com/oktadev/okta-aws-cli-assume-role/blob/main/src/main/java/com/okta/tools/saml/OktaSaml.java#L111 

PR also includes some comments and renaming for additional clarity in some parts of the code.