### PR TITLE
Fix: update pipx command for updating aws-okta-processor in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ a virtualenv while still keeping its dependencies isolated from site-packages::
 
 and, to upgrade to a new version::
 
-    $ pipx install --upgrade aws-okta-processor
+    $ pipx upgrade aws-okta-processor
 
 
 You can also install with `pip`_ in a ``virtualenv``::


### PR DESCRIPTION
### What?

Simple update to the `pipx` command in the [README](https://github.com/godaddy/aws-okta-processor/compare/master...jgould-godaddy:aws-okta-processor:pr/readme-fix?expand=1#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168f) file.

### Why?

Running the command as per the documentation resulted in a CLI error. The fix was simple.

```bash
pipx install --upgrade aws-okta-processor
usage: pipx [-h] [--version]
            {install,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall,reinstall-all,list,run,runpip,ensurepath,environment,completions}
            ...
pipx: error: unrecognized arguments: --upgrade
```