### PR TITLE
Fix pipx command in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ a virtualenv while still keeping its dependencies isolated from site-packages::
 
 and, to upgrade to a new version::
 
-    $ pipx install --upgrade aws-okta-processor
+    $ pipx upgrade aws-okta-processor
 
 
 You can also install with `pip`_ in a ``virtualenv``::


### PR DESCRIPTION
The pipx upgrade command is slightly different from the one used by pip. Current command results in an error.