### PR TITLE
switch tokens to use getpass

### DIFF
--- a/aws_okta_processor/core/okta.py
+++ b/aws_okta_processor/core/okta.py
@@ -85,7 +85,7 @@ class Okta:
                 self.user_name = input_tty()
 
             if not user_pass:
-                user_pass = getpass.getpass()
+                user_pass = getpass.getpass("Password: ")
 
             if not self.organization:
                 print_tty(string="Organization: ", newline=False)
@@ -449,8 +449,7 @@ class FactorTOTP(FactorBase):
 
     @staticmethod
     def payload():
-        print_tty("Token: ", newline=False)
-        return {"passCode": input_tty()}
+        return {"passCode": getpass.getpass("Token: ")}
 
     def retry(self, response):
         return False
@@ -464,8 +463,7 @@ class FactorHardwareToken(FactorBase):
 
     @staticmethod
     def payload():
-        print_tty("Hardware Token: ", newline=False)
-        return {"passCode": input_tty()}
+        return {"passCode": getpass.getpass("Hardware Token: ")}
 
     def retry(self, response):
         return False

--- a/tests/core/test_okta.py
+++ b/tests/core/test_okta.py
@@ -252,7 +252,7 @@ class TestOkta(TestBase):
         self.assertEqual(okta.organization, "organization.okta.com")
         self.assertEqual(okta.okta_session_id, "session_token")
 
-    @patch('aws_okta_processor.core.okta.input_tty')
+    @patch('aws_okta_processor.core.okta.getpass.getpass')
     @patch('aws_okta_processor.core.okta.os.chmod')
     @patch('aws_okta_processor.core.okta.open')
     @patch('aws_okta_processor.core.okta.os.makedirs')
@@ -264,9 +264,9 @@ class TestOkta(TestBase):
             mock_makedirs,
             mock_open,
             mock_chmod,
-            mock_input
+            mock_get_pass
     ):
-        mock_input.return_value = "123456"
+        mock_get_pass.return_value = "123456"
 
         responses.add(
             responses.POST,
@@ -368,7 +368,7 @@ class TestOkta(TestBase):
             call('}')
         ])
 
-    @patch('aws_okta_processor.core.okta.input_tty')
+    @patch('aws_okta_processor.core.okta.getpass.getpass')
     @patch('aws_okta_processor.core.okta.os.chmod')
     @patch('aws_okta_processor.core.okta.open')
     @patch('aws_okta_processor.core.okta.os.makedirs')
@@ -380,9 +380,9 @@ class TestOkta(TestBase):
             mock_makedirs,
             mock_open,
             mock_chmod,
-            mock_input
+            mock_getpass
     ):
-        mock_input.return_value = "123456"
+        mock_getpass.return_value = "123456"
 
         responses.add(
             responses.POST,


### PR DESCRIPTION
`input_tty` causes tokens to be displayed in the terminal. This switches to `getpass` which hides the input.