### PR TITLE
feat(tls): Adding option to skip TLS verification

### DIFF
--- a/aws_okta_processor/commands/authenticate.py
+++ b/aws_okta_processor/commands/authenticate.py
@@ -13,6 +13,7 @@ Options:
     --version                                                   Show version.
     --no-okta-cache                                             Do not read Okta cache.
     --no-aws-cache                                              Do not read AWS cache.
+    --no-tls-verify                                             Do not verify TLS.
     -e --environment                                            Dump auth into ENV variables.
     -u <user_name>, --user=<user_name>                          Okta user name.
     -p <user_pass>, --pass=<user_pass>                          Okta user password.
@@ -85,6 +86,7 @@ CONFIG_MAP = {
     "--silent": "AWS_OKTA_SILENT",
     "--no-okta-cache": "AWS_OKTA_NO_OKTA_CACHE",
     "--no-aws-cache": "AWS_OKTA_NO_AWS_CACHE",
+    "--no-tls-verify": "AWS_OKTA_NO_TLS_VERIFY",
     "--account-alias": "AWS_OKTA_ACCOUNT_ALIAS",
     "--target-shell": "AWS_OKTA_TARGET_SHELL",
 }
@@ -106,6 +108,7 @@ EXTEND_CONFIG_MAP = {
     "AWS_OKTA_SILENT": "silent",
     "AWS_OKTA_NO_OKTA_CACHE": "no-okta-cache",
     "AWS_OKTA_NO_AWS_CACHE": "no-aws-cache",
+    "AWS_OKTA_NO_TLS_VERIFY": "no-tls-verify",
     "AWS_OKTA_ACCOUNT_ALIAS": "account-alias",
     "AWS_OKTA_TARGET_SHELL": "target-shell",
 }

--- a/aws_okta_processor/core/fetcher.py
+++ b/aws_okta_processor/core/fetcher.py
@@ -139,6 +139,7 @@ class SAMLFetcher(CachedCredentialFetcher):
             saml_assertion=saml_assertion,
             accounts_filter=self._configuration.get("AWS_OKTA_ACCOUNT_ALIAS", None),
             sign_in_url=self._configuration.get("AWS_OKTA_SIGN_IN_URL", None),
+            no_tls_verify=self._configuration.get("AWS_OKTA_NO_TLS_VERIFY", None),
         )
 
         return (
@@ -173,6 +174,8 @@ class SAMLFetcher(CachedCredentialFetcher):
         Returns:
             A dictionary containing AWS credentials and expiration time.
         """
+        tls_verify = (self._configuration["AWS_OKTA_NO_TLS_VERIFY"] == None)
+
         # Do NOT load credentials from ENV or ~/.aws/credentials
         client = boto3.client(
             "sts",
@@ -180,6 +183,7 @@ class SAMLFetcher(CachedCredentialFetcher):
             aws_secret_access_key="",
             aws_session_token="",
             region_name=self._configuration["AWS_OKTA_REGION"],
+            verify=tls_verify,
         )
 
         # Get available AWS roles and SAML assertion
@@ -217,6 +221,7 @@ class SAMLFetcher(CachedCredentialFetcher):
                 aws_secret_access_key=credentials["SecretAccessKey"],
                 aws_session_token=credentials["SessionToken"],
                 region_name=self._configuration["AWS_OKTA_REGION"],
+                verify=tls_verify,
             )
             response = client.assume_role(
                 RoleArn=secondary_role_arn,


### PR DESCRIPTION
Hi, team.

This is PR including a feature adding an option to skip TLS verification over HTTPS.
Generally, OKTA is integrated with enterprise environment such a company.
And in the company, infrastructure are secured under a kind of mitm firewall.

As a result, TLS verification could be failed because of firewall so that this feature is required as a workaround.

The option name I added is `--no-tls-verify` following `--no-okta-cache` or `--no-aws-cache`. 
And the option is used to make a request to AWS API using `boto3` and HTTP API using `requests`.

Please review my PR and don't hesitate to feedback if you any concern.

Thanks